### PR TITLE
Fix specs

### DIFF
--- a/src/Rules/Modules.elm
+++ b/src/Rules/Modules.elm
@@ -64,7 +64,7 @@ isBadImport { badModules } name =
     >>> badModules { badModules = Dict.fromList [("a", ""), ("b", "")] } [ "import a", "import b" ]
     [ "a", "b" ]
 
-    >>> badModules { badModules = Dict.fromList [("a", ""), ("b", "")] } ["a", "junk", "import acdf" "import a", "import b"]
+    >>> badModules { badModules = Dict.fromList [("a", ""), ("b", "")] } ["a", "junk", "import acdf", "import a", "import b"]
     [ "a", "b" ]
 -}
 badModules : ModuleConfig a -> List String -> List String

--- a/src/Rules/Modules.elm
+++ b/src/Rules/Modules.elm
@@ -69,7 +69,7 @@ isBadImport { badModules } name =
 -}
 badModules : ModuleConfig a -> List String -> List String
 badModules config =
-    List.Extra.takeWhile isImport
+    List.filter isImport
         >> List.map moduleName
         >> List.filter (isBadImport config)
 

--- a/src/Rules/Modules.elm
+++ b/src/Rules/Modules.elm
@@ -7,8 +7,9 @@ import Dict exposing (Dict)
 
 type alias ModuleConfig a =
     { a
-    | badModules : Dict String String
+        | badModules : Dict String String
     }
+
 
 {-|
     >>> isImport "import Name"
@@ -20,6 +21,7 @@ type alias ModuleConfig a =
 isImport : String -> Bool
 isImport =
     String.startsWith "import "
+
 
 {-|
     >>> moduleName "import Name"
@@ -54,15 +56,16 @@ isBadImport : ModuleConfig a -> String -> Bool
 isBadImport { badModules } name =
     List.member name (Dict.keys badModules)
 
+
 {-|
-   >>> badModules { badModules = Dict.fromList [("a", ""), ("b", "")] } [ "import a", "import c" ]
-   [ "a" ]
+    >>> badModules { badModules = Dict.fromList [("a", ""), ("b", "")] } [ "import a", "import c" ]
+    [ "a" ]
 
-   >>> badModules { badModules = Dict.fromList [("a", ""), ("b", "")] } [ "import a", "import b" ]
-   [ "a", "b" ]
+    >>> badModules { badModules = Dict.fromList [("a", ""), ("b", "")] } [ "import a", "import b" ]
+    [ "a", "b" ]
 
-   >>> badModules { badModules = Dict.fromList [("a", ""), ("b", "")] } ["a", "junk", "import acdf" "import a", "import b"]
-   [ "a", "b" ]
+    >>> badModules { badModules = Dict.fromList [("a", ""), ("b", "")] } ["a", "junk", "import acdf" "import a", "import b"]
+    [ "a", "b" ]
 -}
 badModules : ModuleConfig a -> List String -> List String
 badModules config =


### PR DESCRIPTION
The problem wasn't elm-doc-test it was that the spec was broken.

elm-doc-test printed the correct failure

```
==================================== ERRORS ====================================

-- TYPE MISMATCH --------------------------------- ././Doc/Rules/ModulesSpec.elm

You are giving an argument to something that is not a function!

56|                                                                                                 "import acdf" "import a",
                                                                                                                  ^^^^^^^^^^
Maybe you forgot some parentheses? Or a comma?
```
There was a `,` missing in the List.

I also fixed the implementation of `badModules`. It should be `filter` not `takeWhile` or maybe the expectation is wrong and it should return an empty list in the last example.